### PR TITLE
Add SSR deployment configuration and static build support

### DIFF
--- a/.github/workflows/gcp-deploy-ssr.yml
+++ b/.github/workflows/gcp-deploy-ssr.yml
@@ -1,0 +1,61 @@
+name: Deploy to Google App Engine (GAE) — SSR (manual)
+
+on:
+  workflow_dispatch:
+    inputs:
+      reason:
+        description: "Reason for SSR deployment"
+        required: false
+        default: "Manual SSR deployment"
+
+jobs:
+  build-and-deploy-ssr:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+          cache: "npm"
+
+      - name: Cache Angular CLI build cache
+        uses: actions/cache@v4
+        with:
+          path: .angular/cache
+          key: ${{ runner.os }}-angular-${{ hashFiles('package-lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-angular-
+
+      - name: Install dependencies
+        run: npm ci
+
+      # Skip Piscina-based route discovery during build. On some Linux/CI runners the worker can
+      # reject with a non-Error value, which triggers Angular's assertIsError and fails the build
+      # with "catch clause variable is not an Error instance". Runtime still builds the route tree
+      # on first request (see ServerRouter.from when manifest.routes is undefined).
+      - name: Build SSR app
+        env:
+          NG_BUILD_PARTIAL_SSR: "true"
+        run: npm run build:prod
+
+      - name: Create assets/config.json
+        run: |
+          mkdir -p dist/browser/assets
+          echo '{"API_KEY": "${{ secrets.API_SECRET_KEY }}"}' > dist/browser/assets/config.json
+
+      - name: Google Cloud Auth
+        uses: "google-github-actions/auth@v2"
+        with:
+          credentials_json: "${{ secrets.GCP_SA_KEY }}"
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
+
+      - name: Set up Cloud SDK
+        uses: "google-github-actions/setup-gcloud@v2"
+
+      - name: Deploy SSR to Google App Engine
+        run: |
+          gcloud app deploy client-ssr.yaml dispatch.yaml --quiet --no-cache

--- a/.github/workflows/gcp-deploy.yml
+++ b/.github/workflows/gcp-deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy to Goggle App Engine (GAE)
+name: Deploy to Google App Engine (GAE) — Static
 
 on:
   push:
@@ -165,14 +165,8 @@ jobs:
       - name: Install dependencies
         run: npm ci
 
-      # Skip Piscina-based route discovery during build. On some Linux/CI runners the worker can
-      # reject with a non-Error value, which triggers Angular's assertIsError and fails the build
-      # with "catch clause variable is not an Error instance". Runtime still builds the route tree
-      # on first request (see ServerRouter.from when manifest.routes is undefined).
-      - name: Build Node Project
-        env:
-          NG_BUILD_PARTIAL_SSR: "true"
-        run: npm run build:prod
+      - name: Build static SPA
+        run: npm run build:prod:static
 
       - name: Create assets/config.json
         run: |

--- a/angular.json
+++ b/angular.json
@@ -95,6 +95,11 @@
               "server": false,
               "ssr": false
             },
+            "production-static": {
+              "outputMode": "static",
+              "server": false,
+              "ssr": false
+            },
             "production": {
               "fileReplacements": [
                 {

--- a/client-ssr.yaml
+++ b/client-ssr.yaml
@@ -1,0 +1,51 @@
+# SSR service: Angular SSR (Express) + static browser assets from dist/browser.
+# API traffic is routed to the `api` service via dispatch.yaml (*/api/*).
+# Deploy manually on demand: gcloud app deploy client-ssr.yaml dispatch.yaml
+runtime: nodejs20
+service: default
+
+entrypoint: node dist/server/server.mjs
+
+handlers:
+  # Bot / SEO files (short cache; served from disk without hitting SSR)
+  - url: /robots\.txt
+    static_files: dist/browser/robots.txt
+    upload: dist/browser/robots.txt
+    http_headers:
+      Cache-Control: "no-cache, no-store, must-revalidate"
+
+  - url: /ads\.txt
+    static_files: dist/browser/ads.txt
+    upload: dist/browser/ads.txt
+    http_headers:
+      Cache-Control: "no-cache, no-store, must-revalidate"
+
+  - url: /sitemap\.xml
+    static_files: dist/browser/sitemap.xml
+    upload: dist/browser/sitemap.xml
+    http_headers:
+      Cache-Control: "no-cache, no-store, must-revalidate"
+
+  # Hashed bundles, images, fonts, etc. (long cache; same as express.static in server.ts)
+  - url: /(.*\..+)$
+    static_files: dist/browser/\1
+    upload: dist/browser/(.*\..+)$
+    http_headers:
+      Cache-Control: "public, max-age=31536000"
+
+  # HTML routes, SSR, and anything else → Node (AngularNodeAppEngine)
+  - url: /.*
+    script: auto
+    secure: always
+
+build_env_variables:
+  GOOGLE_NODE_RUN_SCRIPTS: ""
+
+inbound_services:
+  - warmup
+
+automatic_scaling:
+  min_instances: 0
+  max_instances: 3
+  target_cpu_utilization: 0.65
+  target_throughput_utilization: 0.75

--- a/client.yaml
+++ b/client.yaml
@@ -1,12 +1,11 @@
-# Default service: Angular SSR (Express) + static browser assets from dist/browser.
+# Default service: Angular static SPA served entirely from dist/browser.
 # API traffic is routed to the `api` service via dispatch.yaml (*/api/*).
+# For SSR deployment use client-ssr.yaml instead.
 runtime: nodejs20
 service: default
 
-entrypoint: node dist/server/server.mjs
-
 handlers:
-  # Bot / SEO files (short cache; served from disk without hitting SSR)
+  # Bot / SEO files (short cache)
   - url: /robots\.txt
     static_files: dist/browser/robots.txt
     upload: dist/browser/robots.txt
@@ -25,26 +24,34 @@ handlers:
     http_headers:
       Cache-Control: "no-cache, no-store, must-revalidate"
 
-  # Hashed bundles, images, fonts, etc. (long cache; same as express.static in server.ts)
+  # index.html and favicon.ico are NOT content-hashed → must be declared before
+  # the long-cache assets handler so they never get a stale 1-year cache.
+  - url: /index\.html
+    static_files: dist/browser/index.html
+    upload: dist/browser/index.html
+    secure: always
+    http_headers:
+      Cache-Control: "no-cache, no-store, must-revalidate"
+      X-Frame-Options: SAMEORIGIN
+
+  - url: /favicon\.ico
+    static_files: dist/browser/favicon.ico
+    upload: dist/browser/favicon.ico
+    http_headers:
+      Cache-Control: "public, max-age=86400"
+
+  # Hashed bundles, images, fonts, WASM, i18n JSON, etc. (long cache)
   - url: /(.*\..+)$
     static_files: dist/browser/\1
     upload: dist/browser/(.*\..+)$
     http_headers:
       Cache-Control: "public, max-age=31536000"
 
-  # HTML routes, SSR, and anything else → Node (AngularNodeAppEngine)
+  # All SPA routes (no extension) → serve index.html (client-side routing)
   - url: /.*
-    script: auto
+    static_files: dist/browser/index.html
+    upload: dist/browser/index.html
     secure: always
-
-build_env_variables:
-  GOOGLE_NODE_RUN_SCRIPTS: ""
-
-inbound_services:
-  - warmup
-
-automatic_scaling:
-  min_instances: 0
-  max_instances: 3
-  target_cpu_utilization: 0.65
-  target_throughput_utilization: 0.75
+    http_headers:
+      Cache-Control: "no-cache, no-store, must-revalidate"
+      X-Frame-Options: SAMEORIGIN

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "build": "ng build",
     "build:e2e": "ng build --configuration=e2e",
     "build:prod": "node tools/iverbs-builders/write-build-info.cjs && ng build --configuration=production",
+    "build:prod:static": "node tools/iverbs-builders/write-build-info.cjs && ng build --configuration=production,production-static",
     "build:wasm": "asc assembly/levenshtein.ts -o src/assets/wasm/levenshtein.wasm -O3 --exportRuntime --exportTable",
     "generate:verb-component": "ng generate verb-component",
     "test": "ng test",


### PR DESCRIPTION
- Introduced client-ssr.yaml for deploying Angular SSR with Express and static assets.
- Updated angular.json to include a new production-static configuration for static builds.
- Modified client.yaml to clarify that it serves a static SPA and added caching headers.
- Enhanced package.json with a new build command for static production.
- Created a GitHub Actions workflow for manual SSR deployment to Google App Engine.
- Updated existing GCP deployment workflow to build and deploy the static SPA.