### PR TITLE
Add build environment variable to client.yaml for GAE Cloud Build

### DIFF
--- a/client.yaml
+++ b/client.yaml
@@ -55,3 +55,8 @@ handlers:
     http_headers:
       Cache-Control: "no-cache, no-store, must-revalidate"
       X-Frame-Options: SAMEORIGIN
+
+# Prevent GAE Cloud Build from running `npm run build` — the app is already
+# compiled by the GitHub Actions workflow before `gcloud app deploy` is called.
+build_env_variables:
+  GOOGLE_NODE_RUN_SCRIPTS: ""


### PR DESCRIPTION
- Added GOOGLE_NODE_RUN_SCRIPTS variable to prevent GAE Cloud Build from running `npm run build`, as the app is already compiled by GitHub Actions before deployment.